### PR TITLE
Add Dockerfile for container deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Use Node LTS for build stage
+FROM node:18-alpine AS builder
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the application for production
+RUN npm run build
+
+# Production image
+FROM node:18-alpine AS runner
+WORKDIR /app
+
+# Install a lightweight static server
+RUN npm install -g serve
+
+# Copy built assets from builder stage
+COPY --from=builder /app/dist ./dist
+
+# Expose port for the server
+EXPOSE 4173
+
+# Start the server
+CMD ["serve", "-s", "dist", "-l", "4173"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile to build and serve the Vite app

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684feb6fa704832d820cda038f26e9b8