### PR TITLE
Reduce lint errors

### DIFF
--- a/src/components/collaboration/ProjectChat.tsx
+++ b/src/components/collaboration/ProjectChat.tsx
@@ -6,7 +6,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Send, MessageCircle } from "lucide-react";
-import { useProjectMessages } from "@/hooks/useProjectMessages";
+import { useProjectMessages, type ProjectMessage } from "@/hooks/useProjectMessages";
 import { format } from "date-fns";
 
 function generateTempId() {
@@ -137,7 +137,7 @@ const ProjectChat = ({ projectId, userId }: ProjectChatProps) => {
               pending: true,
             }))].sort((a, b) =>
               new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-            ).map((message: any) => {
+            ).map((message: ProjectMessage) => {
               const isOwn = message.sender_id === userId;
               const fullName = message.profiles
                 ? `${message.profiles?.first_name || ''} ${message.profiles?.last_name || ''}`.trim()

--- a/src/components/community/CommentsSection.tsx
+++ b/src/components/community/CommentsSection.tsx
@@ -121,7 +121,7 @@ const CommentsSection = ({ postId }: CommentsSectionProps) => {
       setComments([]);
       setCommentsLoading(false);
     }
-  }, [postId]);
+  }, [postId, loadComments]);
 
   if (commentsLoading) {
     return <CommentsLoadingState />;

--- a/src/components/community/CommunityDiscussions.tsx
+++ b/src/components/community/CommunityDiscussions.tsx
@@ -7,6 +7,7 @@ import DirectMessaging from '@/components/messaging/DirectMessaging';
 import EditPostModal from './EditPostModal';
 import DeleteConfirmationDialog from './DeleteConfirmationDialog';
 import { CommunityPost, UploadedFile } from '@/types/community';
+import type { BasicProfile } from '@/types/profile';
 
 import CommunityHeader from './CommunityHeader';
 import CommunityFilters from './CommunityFilters';
@@ -16,6 +17,7 @@ import CommunitySidebar from './CommunitySidebar';
 interface CommunityDiscussionsProps {
   currentUser: User;
 }
+
 
 const CommunityDiscussions = ({ currentUser }: CommunityDiscussionsProps) => {
   const { 
@@ -80,8 +82,8 @@ const CommunityDiscussions = ({ currentUser }: CommunityDiscussionsProps) => {
     setSelectedCategory('all');
   };
   
-  const getDisplayName = (profile: any) => {
-    if (!profile) return 'Unknown User'; // Guard against null profile
+  const getDisplayName = (profile: BasicProfile | null) => {
+    if (!profile) return 'Unknown User';
     if (profile.first_name || profile.last_name) {
       return `${profile.first_name || ''} ${profile.last_name || ''}`.trim();
     }

--- a/src/components/community/CommunityPostList.tsx
+++ b/src/components/community/CommunityPostList.tsx
@@ -5,6 +5,7 @@ import { Users } from 'lucide-react';
 import PostCard from './PostCard';
 import CreatePostModal from './CreatePostModal';
 import { CommunityPost, UploadedFile } from '@/types/community';
+import type { BasicProfile } from '@/types/profile';
 
 interface CommunityPostListProps {
   posts: CommunityPost[]; // Full list to check if any posts exist at all
@@ -15,7 +16,7 @@ interface CommunityPostListProps {
   onToggleBookmark: (postId: string) => Promise<boolean | void>;
   onHashtagClick: (hashtag: string) => void;
   onMentionClick: (mention: string) => void;
-  onMessageUser: (profile: any) => void;
+  onMessageUser: (profile: BasicProfile) => void;
   onEditPost: (post: CommunityPost) => void;
   onDeletePost: (postId: string, attachments: UploadedFile[] | undefined) => void;
 }

--- a/src/components/community/EnhancedPostContentParser.tsx
+++ b/src/components/community/EnhancedPostContentParser.tsx
@@ -2,12 +2,14 @@
 import { Fragment } from 'react';
 import UserHoverCard from './UserHoverCard';
 
+import type { BasicProfile } from '@/types/profile';
+
 interface EnhancedPostContentParserProps {
   content: string;
   onHashtagClick?: (hashtag: string) => void;
   onMentionClick?: (mention: string) => void;
   currentUserId?: string;
-  onMessageUser?: (profile: any) => void;
+  onMessageUser?: (profile: BasicProfile) => void;
 }
 
 const EnhancedPostContentParser = ({ 

--- a/src/components/community/PostCard.tsx
+++ b/src/components/community/PostCard.tsx
@@ -11,7 +11,8 @@ import EnhancedPostContentParser from './EnhancedPostContentParser';
 import PostEngagement from './PostEngagement';
 import AttachmentDisplay from './AttachmentDisplay';
 import { POST_CATEGORIES } from './PostCategories';
-import { CommunityPost } from '@/types/community';
+import { CommunityPost, UploadedFile } from '@/types/community';
+import type { BasicProfile } from '@/types/profile';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,10 +27,10 @@ interface PostCardProps {
   onToggleBookmark: (postId: string) => void;
   onHashtagClick?: (hashtag: string) => void;
   onMentionClick?: (mention: string) => void;
-  onMessageUser?: (profile: any) => void;
+  onMessageUser?: (profile: BasicProfile) => void;
   currentUserId?: string;
   onEditPost: (post: CommunityPost) => void;
-  onDeletePost: (postId: string, attachments: any[] | undefined) => void;
+  onDeletePost: (postId: string, attachments: UploadedFile[] | undefined) => void;
 }
 
 const PostCard = ({ 

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -3,8 +3,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/hooks/useCommunityModals.ts
+++ b/src/hooks/useCommunityModals.ts
@@ -1,6 +1,7 @@
 
 import { useState } from 'react';
 import { CommunityPost, UploadedFile } from '@/types/community';
+import type { BasicProfile } from '@/types/profile';
 
 export interface ModalState {
   isEditModalOpen: boolean;
@@ -9,7 +10,7 @@ export interface ModalState {
   postIdToDelete: string | null;
   attachmentsToDelete: UploadedFile[] | undefined;
   showMessaging: boolean;
-  selectedProfile: any | null; // Consider defining a Profile type if not already available globally
+  selectedProfile: BasicProfile | null;
 }
 
 export interface ModalActions {
@@ -17,7 +18,7 @@ export interface ModalActions {
   closeEditModal: () => void;
   openDeleteDialog: (postId: string, attachments: UploadedFile[] | undefined) => void;
   closeDeleteDialog: () => void;
-  openMessagingModal: (profile: any) => void;
+  openMessagingModal: (profile: BasicProfile) => void;
   closeMessagingModal: () => void;
 }
 
@@ -30,7 +31,7 @@ export const useCommunityModals = (): ModalState & ModalActions => {
   const [attachmentsToDelete, setAttachmentsToDelete] = useState<UploadedFile[] | undefined>(undefined);
 
   const [showMessaging, setShowMessaging] = useState(false);
-  const [selectedProfile, setSelectedProfile] = useState<any | null>(null);
+  const [selectedProfile, setSelectedProfile] = useState<BasicProfile | null>(null);
 
   const openEditModal = (post: CommunityPost) => {
     setPostToEdit(post);
@@ -54,7 +55,7 @@ export const useCommunityModals = (): ModalState & ModalActions => {
     setAttachmentsToDelete(undefined);
   };
 
-  const openMessagingModal = (profile: any) => {
+  const openMessagingModal = (profile: BasicProfile) => {
     setSelectedProfile(profile);
     setShowMessaging(true);
   };

--- a/src/hooks/useCommunityPostsData.ts
+++ b/src/hooks/useCommunityPostsData.ts
@@ -33,8 +33,8 @@ export const useCommunityPostsData = () => {
         throw postsError;
       }
       
-      let bookmarkedPostIds = new Set<string>();
-      let likedPostIds = new Set<string>(); // For tracking liked posts
+      const bookmarkedPostIds = new Set<string>();
+      const likedPostIds = new Set<string>(); // For tracking liked posts
 
       if (user && postsData) {
         // Fetch bookmarks

--- a/src/hooks/useCommunityPostsRealtime.ts
+++ b/src/hooks/useCommunityPostsRealtime.ts
@@ -1,9 +1,10 @@
 
 import { useEffect, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import type { RealtimeChannel } from '@supabase/supabase-js';
 
 export const useCommunityPostsRealtime = (refreshPosts: () => Promise<void>) => {
-  const channelRef = useRef<any>(null);
+  const channelRef = useRef<RealtimeChannel | null>(null);
 
   useEffect(() => {
     // Clean up any existing channel first

--- a/src/hooks/useDashboardCustomization.ts
+++ b/src/hooks/useDashboardCustomization.ts
@@ -61,7 +61,7 @@ export const useDashboardCustomization = (userId: string) => {
     saveLayout(newLayout);
   };
 
-  const updateWidgetConfig = (widgetId: string, config: any) => {
+  const updateWidgetConfig = (widgetId: string, config: Record<string, unknown>) => {
     const newLayout = {
       ...layout,
       widgets: layout.widgets.map(widget =>

--- a/src/hooks/useMessageNotifications.ts
+++ b/src/hooks/useMessageNotifications.ts
@@ -2,6 +2,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import type { RealtimeChannel } from '@supabase/supabase-js';
 
 interface MessageNotification {
   id: string;
@@ -18,7 +19,7 @@ export const useMessageNotifications = (currentUserId: string) => {
     localStorage.getItem(`lastReadMessages_${currentUserId}`) || new Date().toISOString()
   );
   const { toast } = useToast();
-  const channelRef = useRef<any>(null);
+  const channelRef = useRef<RealtimeChannel | null>(null);
   const currentUserIdRef = useRef<string>(currentUserId);
 
   const updateLastRead = () => {

--- a/src/hooks/useProjectMessages.ts
+++ b/src/hooks/useProjectMessages.ts
@@ -2,6 +2,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import type { RealtimeChannel } from '@supabase/supabase-js';
 
 export interface ProjectMessage {
   id: string;
@@ -9,7 +10,7 @@ export interface ProjectMessage {
   sender_id: string;
   content: string;
   message_type: 'text' | 'system' | 'file_upload' | 'status_update';
-  metadata: any;
+  metadata: Record<string, unknown>;
   created_at: string;
   updated_at: string;
   profiles?: {
@@ -23,7 +24,7 @@ export const useProjectMessages = (projectId: string) => {
   const [messages, setMessages] = useState<ProjectMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
-  const channelRef = useRef<any>(null);
+  const channelRef = useRef<RealtimeChannel | null>(null);
 
   useEffect(() => {
     if (!projectId) {
@@ -126,7 +127,11 @@ export const useProjectMessages = (projectId: string) => {
     };
   }, [projectId, toast]);
 
-  const sendMessage = async (content: string, messageType: 'text' | 'system' | 'file_upload' | 'status_update' = 'text', metadata: any = {}) => {
+  const sendMessage = async (
+    content: string,
+    messageType: 'text' | 'system' | 'file_upload' | 'status_update' = 'text',
+    metadata: Record<string, unknown> = {}
+  ) => {
     try {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) throw new Error('Not authenticated');

--- a/src/hooks/useProjectPresence.ts
+++ b/src/hooks/useProjectPresence.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import type { RealtimeChannel } from '@supabase/supabase-js';
 import { useToast } from '@/hooks/use-toast';
 
 interface UserPresence {
@@ -20,7 +21,7 @@ export const useProjectPresence = (projectId: string, userId: string) => {
   const [presenceUsers, setPresenceUsers] = useState<UserPresence[]>([]);
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
-  const channelRef = useRef<any>(null);
+  const channelRef = useRef<RealtimeChannel | null>(null);
   const isSubscribedRef = useRef(false);
 
   useEffect(() => {

--- a/src/hooks/useSimpleDirectMessages.ts
+++ b/src/hooks/useSimpleDirectMessages.ts
@@ -2,6 +2,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import type { RealtimeChannel } from '@supabase/supabase-js';
 
 export interface DirectMessage {
   id: string;
@@ -26,7 +27,7 @@ export const useSimpleDirectMessages = (
   const [isRealtimeConnected, setIsRealtimeConnected] = useState(false);
   const { toast } = useToast();
   
-  const channelRef = useRef<any>(null);
+  const channelRef = useRef<RealtimeChannel | null>(null);
   const pollIntervalRef = useRef<NodeJS.Timeout>();
   const lastMessageIdRef = useRef<string>('');
 
@@ -141,7 +142,7 @@ export const useSimpleDirectMessages = (
         },
         (payload) => {
           console.log('📨 Real-time message received:', payload);
-          const newMessage = payload.new as any;
+          const newMessage = payload.new as DirectMessage;
           
           // Check if this message is for our conversation
           const isForThisConversation = 
@@ -155,7 +156,7 @@ export const useSimpleDirectMessages = (
         }
       )
       // Listen for typing indicators
-      .on('broadcast', { event: 'typing' }, ({ payload }: { payload: any }) => {
+      .on('broadcast', { event: 'typing' }, ({ payload }: { payload: { user_id: string; typing: boolean } }) => {
         console.log('⌨️ Typing indicator received:', payload);
         if (payload.user_id === recipientId) {
           onRecipientTyping(payload.typing);

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -66,7 +66,7 @@ const ProjectDetail = () => {
       } else {
         setUserRole(roleData.role);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       console.error("Auth error:", error);
       navigate("/login");
     } finally {
@@ -112,7 +112,7 @@ const ProjectDetail = () => {
       console.log("Project data fetched successfully:", projectData);
       setProject(projectData);
 
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error fetching project:", error);
       toast({
         title: "Error",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -49,7 +49,7 @@ const Settings = () => {
         .single();
 
       setUserRole(roleData?.role || "artist");
-    } catch (error) {
+    } catch (error: unknown) {
       console.error("Auth error:", error);
       navigate("/login");
     } finally {
@@ -68,7 +68,7 @@ const Settings = () => {
       if (error) throw error;
       setProfile(profileData);
       setEditData(profileData);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error fetching profile:", error);
       toast({
         title: "Error",
@@ -96,7 +96,7 @@ const Settings = () => {
         title: "Success",
         description: "Profile updated successfully"
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error updating profile:", error);
       toast({
         title: "Error",

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -9,7 +9,7 @@ export interface DashboardWidget {
   config?: {
     showCount?: number;
     timeRange?: 'week' | 'month' | 'quarter';
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,7 @@
+export interface BasicProfile {
+  id?: string;
+  first_name?: string | null;
+  last_name?: string | null;
+  username?: string | null;
+  avatar_url?: string | null;
+}

--- a/src/utils/apiEndpoints.ts
+++ b/src/utils/apiEndpoints.ts
@@ -54,7 +54,7 @@ Example folder structure on your server:
 export const extractUserIdFromUrl = (url: string): string | null => {
   try {
     const urlPath = new URL(url).pathname;
-    const match = urlPath.match(/\/api\/files\/([^\/]+)\//);
+    const match = urlPath.match(/\/api\/files\/([^/]+)\//);
     return match ? match[1] : null;
   } catch {
     return null;

--- a/src/utils/discussionUtils.ts
+++ b/src/utils/discussionUtils.ts
@@ -35,7 +35,7 @@ export const processMessageContent = (content: string) => {
   const mentionRegex = /@(\w+)/g;
   const hashtagRegex = /#(\w+)/g;
 
-  let processedContent = content
+  const processedContent = content
     .replace(mentionRegex, `<span class="bg-blue-500/20 text-blue-300 px-1 rounded">@$1</span>`)
     .replace(hashtagRegex, `<span class="bg-purple-500/20 text-purple-300 px-1 rounded">#$1</span>`);
 

--- a/supabase/functions/get-vm-status/index.ts
+++ b/supabase/functions/get-vm-status/index.ts
@@ -45,7 +45,8 @@ serve(async (req) => {
 
     // Calculate current costs for running VMs
     const vmsWithCosts = vmInstances?.map(vm => {
-      const activeUsage = vm.vm_usage_logs?.find((log: any) => log.status === 'active')
+      interface VmUsageLog { status: string; start_time: string }
+      const activeUsage = vm.vm_usage_logs?.find((log: VmUsageLog) => log.status === 'active')
       let currentCost = 0
       let runtimeMinutes = 0
 


### PR DESCRIPTION
## Summary
- expand `BasicProfile` with an optional avatar field
- tighten `useRef` generics for realtime hooks
- clean up error handling in settings and project pages
- use `Record<string, unknown>` for dashboard config
- fix a prefer-const warning and tweak textarea props

## Testing
- `npm run lint` *(fails: 94 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686007298bec832db4f1b177a6b00615