### PR TITLE
Load Supabase config from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
+

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment variables
+
+Copy `.env.example` to `.env` and set `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_KEY` with your own Supabase credentials. The `.env` file is ignored by Git.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/4bfb95d9-8671-4636-b185-bcb9d5526848) and click on Share -> Publish.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://shdlczoodmekrydnwqsn.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNoZGxjem9vZG1la3J5ZG53cXNuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkyNzk3NzQsImV4cCI6MjA2NDg1NTc3NH0.RTqTGNLgeEahOOzP6wixGq6iQFTeOpDQrjOngXLmdOA";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- read Supabase credentials from `import.meta.env`
- provide placeholder values in `.env.example`
- document env vars in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686029ba5064832daebfc49d2d1ff135