### PR TITLE
Fix lint/test env and clean logging

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/supabase/functions/terminate-vm/index.ts
+++ b/supabase/functions/terminate-vm/index.ts
@@ -82,8 +82,7 @@ serve(async (req) => {
           hourly_rate: activeUsage.hourly_rate
         }
       })
-
-      console.log('Charge result:', chargeResult)
+      // Charge result is ignored in this serverless context
     }
 
     // Update VM status to terminated


### PR DESCRIPTION
## Summary
- remove `console.log` from terminate-vm function
- add `.npmrc` so `npm install` works with peer deps

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68603b6e8898832d8528e353bdd69107