### PR TITLE
Fix auth update without page reload

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -132,8 +132,8 @@ const Dashboard = () => {
           navigate("/login");
         } else if (event === 'SIGNED_IN' && session) {
           setUser(session.user);
-          // Refetch roles when user signs in
-          window.location.reload();
+          // Refetch roles when user signs in without full reload
+          await checkAuth();
         }
       }
     );


### PR DESCRIPTION
## Summary
- refresh roles when signing in without reloading

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_686419817560832d93311dff5e068cff